### PR TITLE
Fix Docker networking and environment variable configuration in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -65,9 +65,11 @@ jobs:
           docker pull ${DOCKER_USER}/stock_servs:latest
           
           echo '=== Starting new container ==='
-          docker run -d --name stock_servs -p 8000:8000 \
-            -e DB_SSM_PARAM_NAME='DB_SSM_PARAM_NAME' \
-            -e AWS_REGION='us-east-1' \
+          # Using --network host to allow container to access EC2 Instance Metadata Service (IMDS)
+          # This enables the container to use the EC2 IAM role for AWS credentials
+          docker run -d --name stock_servs --network host \
+            -e DB_SSM_PARAM_NAME='${{ secrets.DB_SSM_PARAM_NAME }}' \
+            -e AWS_REGION='${{ secrets.AWS_REGION }}' \
             -e FYERS_CLIENT_ID='${{ secrets.FYERS_CLIENT_ID }}' \
             -e FYERS_SECRET_KEY='${{ secrets.FYERS_SECRET_KEY }}' \
             -e FYERS_REDIRECT_URI='${{ secrets.FYERS_REDIRECT_URI }}' \


### PR DESCRIPTION
## Summary
Updated the Docker container deployment configuration to properly support AWS IAM role authentication and fix environment variable handling.

## Key Changes
- **Network Configuration**: Changed from port mapping (`-p 8000:8000`) to `--network host` to allow the container to access the EC2 Instance Metadata Service (IMDS), enabling the container to use the EC2 IAM role for AWS credentials
- **Environment Variables**: Updated `DB_SSM_PARAM_NAME` and `AWS_REGION` to use GitHub secrets (`${{ secrets.* }}`) instead of hardcoded placeholder values
- **Documentation**: Added inline comments explaining the networking change and its purpose

## Implementation Details
The `--network host` flag allows the containerized application to access the EC2 instance metadata service at `169.254.169.254`, which is necessary for retrieving temporary AWS credentials from the attached IAM role. This eliminates the need to explicitly pass AWS credentials as environment variables, improving security by leveraging the instance's IAM role.

The environment variable fixes ensure that sensitive configuration values are properly retrieved from GitHub secrets rather than using placeholder strings.