### PR TITLE
Fix Fyers connection and session expiry handling

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,6 +57,7 @@ jobs:
         FYERS_CLIENT_ID: ${{ secrets.FYERS_CLIENT_ID }}
         FYERS_SECRET_KEY: ${{ secrets.FYERS_SECRET_KEY }}
         FYERS_REDIRECT_URI: ${{ secrets.FYERS_REDIRECT_URI }}
+        FYERS_PIN: ${{ secrets.FYERS_PIN }}
       run: |
         ssh -o StrictHostKeyChecking=no -i ~/.ssh/id_rsa "${EC2_USER}@${EC2_HOST}" "
           echo '=== Stopping old container ==='
@@ -76,6 +77,7 @@ jobs:
             -e FYERS_CLIENT_ID='${FYERS_CLIENT_ID}' \
             -e FYERS_SECRET_KEY='${FYERS_SECRET_KEY}' \
             -e FYERS_REDIRECT_URI='${FYERS_REDIRECT_URI}' \
+            -e FYERS_PIN='${FYERS_PIN}' \
             --restart unless-stopped \
             ${DOCKER_USER}/stock_servs:latest
           


### PR DESCRIPTION
## Summary
- **Fix expired session handling**: Auto-detect 401 responses in api.js, clear stale tokens, and redirect to login instead of showing confusing "Invalid or expired token" errors
- **Add FYERS_PIN to deployment**: Pass FYERS_PIN env var to Docker container so Fyers token auto-refresh works in production
- **FYERS_REDIRECT_URI** GitHub secret updated to `https://app.marketmindx.in/fyers/callback` (was pointing to localhost)

## Test plan
- [ ] Deploy to production
- [ ] Log in and verify session works
- [ ] Connect Fyers — should redirect to Fyers, complete OTP, and redirect back successfully
- [ ] Verify Fyers connection persists after page reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)